### PR TITLE
Update US and GB translations to replace "swamp"

### DIFF
--- a/gamedata/localization/en-GB.json
+++ b/gamedata/localization/en-GB.json
@@ -548,7 +548,7 @@
 				"name": "_MISSING_Crossbows"
 			},
 			"dyeing": {
-				"description": "_MISSING_Learn to grow flowers in swamps, allowing you to add color to your world.",
+				"description": "_MISSING_Learn to grow flowers in marshes, allowing you to add color to your world.",
 				"name": "_MISSING_Dyeing"
 			},
 			"elevator": {
@@ -736,7 +736,7 @@
 				"name": "_MISSING_Statistics Board"
 			},
 			"steel": {
-				"description": "_MISSING_Unlocks steel, lead and mineral oil. These resources are necessary for the construction of more modern machinery. Lead ore is found in swamps, and coal is located below mammoth trees.",
+				"description": "_MISSING_Unlocks steel, lead and mineral oil. These resources are necessary for the construction of more modern machinery. Lead ore is found in marshes, and coal is located below mammoth trees.",
 				"name": "_MISSING_Steel, Lead and Mineral Oil"
 			},
 			"steellockbox": {
@@ -1036,7 +1036,7 @@
 				"description": "_MISSING_Trade and expand to get access to unique resources",
 				"header": "_MISSING_Colony Points & Colonization",
 				"text1": "_MISSING_Unlock and place the Merchant’s Hub. Right-click it to open its interface. Sell items to earn Colony Points. Among others, points can be spent on upgrades like the colonist limit in the Colony Points page.",
-				"text2": "_MISSING_This world contains multiple regions with unique resources. There are mountaintops covered with snow, heaths covered in purple, swamps and mammoth trees. Unlock and equip the astrolabe to find them easily.",
+				"text2": "_MISSING_This world contains multiple regions with unique resources. There are mountaintops covered with snow, heaths covered in purple, marshes and mammoth trees. Unlock and equip the astrolabe to find them easily.",
 				"text3": "_MISSING_Unlock outposts, purchase an Outpost Banner and carry it with you while you explore. Place it to start an Outpost. Its stockpile and scientific progress are shared with the main colony and other outposts. Build outposts in the regions mentioned above to get access to their resources."
 			},
 			"page6_2": {
@@ -1601,7 +1601,7 @@
 		"lanternorange": "Extra cozy",
 		"lanternred": "These are popular in Amsterdam too",
 		"lanternyellow": "Expensive torch",
-		"leadore": "_MISSING_Found in swamps.",
+		"leadore": "_MISSING_Found in marshes.",
 		"leavestaiga": "I've got a Christmas feeling now",
 		"leavestemperate": "Try to jump into a pile of these from a high tower",
 		"linen": "Lingerie means underwear made of linen",

--- a/gamedata/localization/en-US.json
+++ b/gamedata/localization/en-US.json
@@ -548,7 +548,7 @@
 				"name": "Crossbows"
 			},
 			"dyeing": {
-				"description": "Learn to grow flowers in swamps, allowing you to add color to your world.",
+				"description": "Learn to grow flowers in marshes, allowing you to add color to your world.",
 				"name": "Dyeing"
 			},
 			"elevator": {
@@ -736,7 +736,7 @@
 				"name": "Statistics Board"
 			},
 			"steel": {
-				"description": "Unlocks steel, lead and mineral oil. These resources are necessary for the construction of more modern machinery. Lead ore is found in swamps, and coal is located below mammoth trees.",
+				"description": "Unlocks steel, lead and mineral oil. These resources are necessary for the construction of more modern machinery. Lead ore is found in marshes, and coal is located below mammoth trees.",
 				"name": "Steel, Lead and Mineral Oil"
 			},
 			"steellockbox": {
@@ -1036,7 +1036,7 @@
 				"description": "Trade and expand to get access to unique resources",
 				"header": "Colony Points & Colonization",
 				"text1": "Unlock and place the Merchant’s Hub. Right-click it to open its interface. Sell items to earn Colony Points. Among others, points can be spent on upgrades like the colonist limit in the Colony Points page.",
-				"text2": "This world contains multiple regions with unique resources. There are mountaintops covered with snow, heaths covered in purple, swamps and mammoth trees. Unlock and equip the astrolabe to find them easily.",
+				"text2": "This world contains multiple regions with unique resources. There are mountaintops covered with snow, heaths covered in purple, marshes and mammoth trees. Unlock and equip the astrolabe to find them easily.",
 				"text3": "Unlock outposts, purchase an Outpost Banner and carry it with you while you explore. Place it to start an Outpost. Its stockpile and scientific progress are shared with the main colony and other outposts. Build outposts in the regions mentioned above to get access to their resources."
 			},
 			"page6_2": {
@@ -1601,7 +1601,7 @@
 		"lanternorange": "Extra cozy",
 		"lanternred": "These are popular in Amsterdam too",
 		"lanternyellow": "Expensive torch",
-		"leadore": "Found in swamps.",
+		"leadore": "Found in marshes.",
 		"leavestaiga": "I've got a Christmas feeling now",
 		"leavestemperate": "Try to jump into a pile of these from a high tower",
 		"linen": "Lingerie means underwear made of linen",


### PR DESCRIPTION
Replaced references to "swamp" with "marsh" in both en-US and en-GB localization files, to align with biome name.